### PR TITLE
update dependency on faraday to 0.9.x

### DIFF
--- a/alchemy-api-rb.gemspec
+++ b/alchemy-api-rb.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = AlchemyAPI::VERSION
 
-  gem.add_dependency             'faraday',             '~> 0.8.0'
+  gem.add_dependency             'faraday',             '~> 0.9.0'
   gem.add_dependency             'excon',               '~> 0.28'
 
   gem.add_development_dependency 'minitest',            '~> 5.4.0'


### PR DESCRIPTION
Hi,

We had a conflict between versions of faraday between alchemy-api-rb and twitter gems. With updated reference, minitest suite is green and gem functions in our project.