### PR TITLE
Use HTTPS Endpoint for AlchemyAPI

### DIFF
--- a/lib/alchemy_api.rb
+++ b/lib/alchemy_api.rb
@@ -16,7 +16,7 @@ require 'alchemy-api/taxonomy'
 require 'alchemy-api/image_tagging'
 
 module AlchemyAPI
-  BASE_URL = 'http://access.alchemyapi.com/calls/'
+  BASE_URL = 'https://access.alchemyapi.com/calls/'
 
   def self.config
     Config

--- a/spec/alchemy_api_spec.rb
+++ b/spec/alchemy_api_spec.rb
@@ -3,8 +3,8 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 describe AlchemyAPI do
   subject { AlchemyAPI }
 
-  it 'knows the alchemy api url' do
-    AlchemyAPI::BASE_URL.must_be :==, 'http://access.alchemyapi.com/calls/'
+  it 'knows the secure alchemy api url' do
+    AlchemyAPI::BASE_URL.must_be :==, 'https://access.alchemyapi.com/calls/'
   end
 
   it 'allows you to set the key directly' do

--- a/spec/vcr_cassettes/author_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/author_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetAuthor
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetAuthor
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>Google is a large, by Joe Smith</body></html>&outputMode=json

--- a/spec/vcr_cassettes/author_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/author_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetAuthor
+    uri: https://access.alchemyapi.com/calls/url/URLGetAuthor
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://blog.alchemyapi.com/&outputMode=json

--- a/spec/vcr_cassettes/category_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/category_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetCategory
+    uri: https://access.alchemyapi.com/calls/text/TextGetCategory
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=lorem ipsum&outputMode=json

--- a/spec/vcr_cassettes/category_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/category_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetCategory
+    uri: https://access.alchemyapi.com/calls/url/URLGetCategory
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.alchemyapi.com/&outputMode=json

--- a/spec/vcr_cassettes/concept_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/concept_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetRankedConcepts
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetRankedConcepts
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>Google is a large company</body></html>&outputMode=json

--- a/spec/vcr_cassettes/concept_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/concept_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetRankedConcepts
+    uri: https://access.alchemyapi.com/calls/text/TextGetRankedConcepts
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=Google is a large company&outputMode=json

--- a/spec/vcr_cassettes/concept_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/concept_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetRankedConcepts
+    uri: https://access.alchemyapi.com/calls/url/URLGetRankedConcepts
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.alchemy.com&outputMode=json

--- a/spec/vcr_cassettes/entity_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/entity_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetRankedNamedEntities
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetRankedNamedEntities
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>Google is a large company</body></html>&outputMode=json

--- a/spec/vcr_cassettes/entity_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/entity_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetRankedNamedEntities
+    uri: https://access.alchemyapi.com/calls/text/TextGetRankedNamedEntities
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=Google is a large company&outputMode=json

--- a/spec/vcr_cassettes/entity_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/entity_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetRankedNamedEntities
+    uri: https://access.alchemyapi.com/calls/url/URLGetRankedNamedEntities
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.google.com&outputMode=json

--- a/spec/vcr_cassettes/image_tagging_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/image_tagging_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetRankedImageKeywords
+    uri: https://access.alchemyapi.com/calls/url/URLGetRankedImageKeywords
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://demo1.alchemyapi.com/images/vision/emaxfpo.jpg&outputMode=json

--- a/spec/vcr_cassettes/keyword_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/keyword_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetRankedKeywords
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetRankedKeywords
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>foo bar</body></html>&outputMode=json

--- a/spec/vcr_cassettes/keyword_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/keyword_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetRankedKeywords
+    uri: https://access.alchemyapi.com/calls/text/TextGetRankedKeywords
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=lorem ipsum&outputMode=json

--- a/spec/vcr_cassettes/keyword_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/keyword_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetRankedKeywords
+    uri: https://access.alchemyapi.com/calls/url/URLGetRankedKeywords
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.google.com&outputMode=json

--- a/spec/vcr_cassettes/language_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/language_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetLanguage
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetLanguage
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>Lorem ipsum dolor sit amet.</body></html>&outputMode=json

--- a/spec/vcr_cassettes/language_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/language_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetLanguage
+    uri: https://access.alchemyapi.com/calls/text/TextGetLanguage
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=Lorem ipsum dolor sit amet.&outputMode=json

--- a/spec/vcr_cassettes/language_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/language_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetLanguage
+    uri: https://access.alchemyapi.com/calls/url/URLGetLanguage
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.alchemyapi.com/&outputMode=json

--- a/spec/vcr_cassettes/relation_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/relation_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetRelations
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetRelations
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>Google is a large company</body></html>&outputMode=json

--- a/spec/vcr_cassettes/relation_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/relation_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetRelations
+    uri: https://access.alchemyapi.com/calls/text/TextGetRelations
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=Google is a large company&outputMode=json

--- a/spec/vcr_cassettes/relation_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/relation_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetRelations
+    uri: https://access.alchemyapi.com/calls/url/URLGetRelations
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.alchemy.com&outputMode=json

--- a/spec/vcr_cassettes/sentiment_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/sentiment_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetTextSentiment
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetTextSentiment
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>Alchemy is cool</body></html>&outputMode=json

--- a/spec/vcr_cassettes/sentiment_basic_text_json_search.yml
+++ b/spec/vcr_cassettes/sentiment_basic_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetTextSentiment
+    uri: https://access.alchemyapi.com/calls/text/TextGetTextSentiment
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=Alchemy is cool&outputMode=json

--- a/spec/vcr_cassettes/sentiment_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/sentiment_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetTextSentiment
+    uri: https://access.alchemyapi.com/calls/url/URLGetTextSentiment
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.alchemyapi.com&outputMode=json

--- a/spec/vcr_cassettes/sentiment_targeted_html_json_search.yml
+++ b/spec/vcr_cassettes/sentiment_targeted_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetTargetedSentiment
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetTargetedSentiment
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>AlchemyAPI is cool</body></html>&target=alchemyapi&outputMode=json

--- a/spec/vcr_cassettes/sentiment_targeted_text_json_search.yml
+++ b/spec/vcr_cassettes/sentiment_targeted_text_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/text/TextGetTargetedSentiment
+    uri: https://access.alchemyapi.com/calls/text/TextGetTargetedSentiment
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&text=AlchemyAPI is cool&target=alchemyapi&outputMode=json

--- a/spec/vcr_cassettes/sentiment_targeted_url_json_search.yml
+++ b/spec/vcr_cassettes/sentiment_targeted_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetTargetedSentiment
+    uri: https://access.alchemyapi.com/calls/url/URLGetTargetedSentiment
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.alchemyapi.com&target=alchemyapi&outputMode=json

--- a/spec/vcr_cassettes/text_basic_html_json_search.yml
+++ b/spec/vcr_cassettes/text_basic_html_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/html/HTMLGetText
+    uri: https://access.alchemyapi.com/calls/html/HTMLGetText
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&html=<html><body>foo bar</body></html>&outputMode=json

--- a/spec/vcr_cassettes/text_basic_url_json_search.yml
+++ b/spec/vcr_cassettes/text_basic_url_json_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://access.alchemyapi.com/calls/url/URLGetText
+    uri: https://access.alchemyapi.com/calls/url/URLGetText
     body:
       encoding: US-ASCII
       string: apikey=ALCHEMY_KEY&url=http://www.google.com&outputMode=json


### PR DESCRIPTION
## Description
In order to securely send information to the AlchemyAPI I've switched the `BASE_URL` to use `https` vs. `http`(referenced [from here](http://www.alchemyapi.com/api/calling-the-api)).

I thought about making it configurable and have an `AlchemyAPI.use_ssl = true` configuration but wasn't sure why you _wouldn't_ want to go over HTTPS.

As always, feedback welcome.