### PR TITLE
Form Encode URL Parameters

### DIFF
--- a/lib/alchemy-api/base.rb
+++ b/lib/alchemy-api/base.rb
@@ -7,8 +7,9 @@ module AlchemyAPI
 
     def search(opts)
       check_options(opts)
+      body = { apikey: Config.apikey }.merge!(merged_options(options))
 
-      @response = connection.post(path, construct_body)
+      @response = connection.post(path, body)
 
       parsed_response
     end
@@ -39,6 +40,7 @@ module AlchemyAPI
 
     def connection
       @connection ||= Faraday.new(url: BASE_URL) do |builder|
+        builder.request :url_encoded
         builder.adapter :excon
       end
     end
@@ -65,12 +67,6 @@ module AlchemyAPI
 
     def path
       "#{mode}/#{web_method}"
-    end
-
-    def construct_body
-      body = { apikey: Config.apikey }.merge!(merged_options(options))
-
-      body.map { |e| e.join('=') }.join('&')
     end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -16,6 +16,14 @@ describe AlchemyAPI::Base do
           .handlers
           .must_include Faraday::Adapter::Excon
       end
+
+      it 'form-encodes POST parameters' do
+        subject
+          .send(:connection)
+          .builder
+          .handlers
+          .must_include Faraday::Request::UrlEncoded
+      end
     end
   end
 


### PR DESCRIPTION
## Description
While using the `alchemy_api` gem I noticed that when I was doing a relation extraction that it was truncating my `:text` parameter when the text included an `&` character in it.

```ruby
AlchemyAPI.search(:relation_extraction, text: 'This has an & in the text, but everything after this will not be passed along to Alchemy')
```
When that happens, it only passes the `"This has an "` as the `:text` parameters because of the `&`.

## Solution
By telling `Faraday` to `builder.request :url_encoded` you can then simply pass the `Hash` directly to it and it will handle this for you.